### PR TITLE
Improved the build system of root and root_easysetup by modifying the following changes

### DIFF
--- a/root/programs/C#/3_Build_PortableClassLibrary.bat
+++ b/root/programs/C#/3_Build_PortableClassLibrary.bat
@@ -1,0 +1,26 @@
+setlocal
+
+@rem --------------------------------------------------
+@rem Turn off the echo function.
+@rem --------------------------------------------------
+@echo off
+
+@rem --------------------------------------------------
+@rem Get the path to the executable file.
+@rem --------------------------------------------------
+set CURRENT_DIR=%~dp0
+
+@rem --------------------------------------------------
+@rem Execution of the common processing.
+@rem --------------------------------------------------
+call %CURRENT_DIR%z_Common.bat
+
+rem --------------------------------------------------
+rem Build the batch PortableClassLibrary(PortableClassLibrary)
+rem --------------------------------------------------
+%BUILDFILEPATH% %COMMANDLINE% "Frameworks\PortableClassLibrary\PortableClassLibrary.sln"
+
+pause
+
+rem -------------------------------------------------------
+endlocal

--- a/root/programs/C#/z_Common.bat
+++ b/root/programs/C#/z_Common.bat
@@ -5,20 +5,19 @@
 @rem --------------------------------------------------
 @rem Specifying Build tool.
 @rem --------------------------------------------------
-set BUILDFILEPATH="C:\Program Files\Microsoft Visual Studio 10.0\Common7\IDE\devenv.com"
+set BUILDFILEPATH="C:\Windows\Microsoft.NET\Framework\v4.0.30319\MSBuild.exe"
 
-set BUILDFILEPATH2.0="C:\Program Files\Microsoft Visual Studio 8\Common7\IDE\devenv.com"
-set BUILDFILEPATH3.5="C:\Program Files\Microsoft Visual Studio 9.0\Common7\IDE\devenv.com"
-set BUILDFILEPATH4.0="C:\Program Files\Microsoft Visual Studio 10.0\Common7\IDE\devenv.com"
-set BUILDFILEPATH4.5="C:\Program Files\Microsoft Visual Studio 11.0\Common7\IDE\devenv.com"
-set BUILDFILEPATH4.5.1="C:\Program Files\Microsoft Visual Studio 12.0\Common7\IDE\IDE\devenv.com"
+set BUILDFILEPATH2.0="C:\Windows\Microsoft.NET\Framework\v2.0.50727\MSBuild.exe"
+set BUILDFILEPATH3.5="C:\Windows\Microsoft.NET\Framework\v3.5\MSBuild.exe"
+set BUILDFILEPATH4.0="C:\Windows\Microsoft.NET\Framework\v4.0.30319\MSBuild.exe"
 
 @echo --------------------------------------------------
 @echo The choice of build configuration (Debug / Release).
 @echo --------------------------------------------------
 set BUILD_CONFIG=Debug
+set VisualStudioVersion=10.0
 
 @echo --------------------------------------------------
 @echo Creating a build command.
 @echo --------------------------------------------------
-set COMMANDLINE=/build %BUILD_CONFIG%
+set COMMANDLINE=/p:Configuration=%BUILD_CONFIG%

--- a/root/programs/C#/z_Common2.bat
+++ b/root/programs/C#/z_Common2.bat
@@ -3,13 +3,20 @@
 @rem --------------------------------------------------
 
 @rem --------------------------------------------------
+@rem Set Program Files path
+@rem --------------------------------------------------
+reg Query "HKLM\Hardware\Description\System\CentralProcessor\0" | find /i "x86" > NUL && set PROGRAM_FILES=Program Files || set PROGRAM_FILES=Program Files (x86)
+
+@rem --------------------------------------------------
 @rem Specifying Build tool.
 @rem --------------------------------------------------
-set BUILDFILEPATH="C:\Windows\Microsoft.NET\Framework\v4.0.30319\MSBuild.exe"
+set BUILDFILEPATH="C:\%PROGRAM_FILES%\Microsoft Visual Studio 10.0\Common7\IDE\devenv.com"
 
-set BUILDFILEPATH2.0="C:\Windows\Microsoft.NET\Framework\v2.0.50727\MSBuild.exe"
-set BUILDFILEPATH3.5="C:\Windows\Microsoft.NET\Framework\v3.5\MSBuild.exe"
-set BUILDFILEPATH4.0="C:\Windows\Microsoft.NET\Framework\v4.0.30319\MSBuild.exe"
+set BUILDFILEPATH2.0="C:\%PROGRAM_FILES%\Microsoft Visual Studio 8\Common7\IDE\devenv.com"
+set BUILDFILEPATH3.5="C:\%PROGRAM_FILES%\Microsoft Visual Studio 9.0\Common7\IDE\devenv.com"
+set BUILDFILEPATH4.0="C:\%PROGRAM_FILES%\Microsoft Visual Studio 10.0\Common7\IDE\devenv.com"
+set BUILDFILEPATH4.5="C:\%PROGRAM_FILES%\Microsoft Visual Studio 11.0\Common7\IDE\devenv.com"
+set BUILDFILEPATH4.5.1="C:\%PROGRAM_FILES%\Microsoft Visual Studio 12.0\Common7\IDE\IDE\devenv.com"
 
 @echo --------------------------------------------------
 @echo The choice of build configuration (Debug / Release).
@@ -19,4 +26,4 @@ set BUILD_CONFIG=Debug
 @echo --------------------------------------------------
 @echo Creating a build command.
 @echo --------------------------------------------------
-set COMMANDLINE=/p:Configuration=%BUILD_CONFIG%
+set COMMANDLINE=/build %BUILD_CONFIG%

--- a/root/programs/VB/z_Common.bat
+++ b/root/programs/VB/z_Common.bat
@@ -5,20 +5,19 @@
 @rem --------------------------------------------------
 @rem Specifying Build tool.
 @rem --------------------------------------------------
-set BUILDFILEPATH="C:\Program Files\Microsoft Visual Studio 10.0\Common7\IDE\devenv.com"
+set BUILDFILEPATH="C:\Windows\Microsoft.NET\Framework\v4.0.30319\MSBuild.exe"
 
-set BUILDFILEPATH2.0="C:\Program Files\Microsoft Visual Studio 8\Common7\IDE\devenv.com"
-set BUILDFILEPATH3.5="C:\Program Files\Microsoft Visual Studio 9.0\Common7\IDE\devenv.com"
-set BUILDFILEPATH4.0="C:\Program Files\Microsoft Visual Studio 10.0\Common7\IDE\devenv.com"
-set BUILDFILEPATH4.5="C:\Program Files\Microsoft Visual Studio 11.0\Common7\IDE\devenv.com"
-set BUILDFILEPATH4.5.1="C:\Program Files\Microsoft Visual Studio 12.0\Common7\IDE\IDE\devenv.com"
+set BUILDFILEPATH2.0="C:\Windows\Microsoft.NET\Framework\v2.0.50727\MSBuild.exe"
+set BUILDFILEPATH3.5="C:\Windows\Microsoft.NET\Framework\v3.5\MSBuild.exe"
+set BUILDFILEPATH4.0="C:\Windows\Microsoft.NET\Framework\v4.0.30319\MSBuild.exe"
 
 @echo --------------------------------------------------
 @echo The choice of build configuration (Debug / Release).
 @echo --------------------------------------------------
 set BUILD_CONFIG=Debug
+set VisualStudioVersion=10.0
 
 @echo --------------------------------------------------
 @echo Creating a build command.
 @echo --------------------------------------------------
-set COMMANDLINE=/build %BUILD_CONFIG%
+set COMMANDLINE=/p:Configuration=%BUILD_CONFIG%

--- a/root/programs/VB/z_Common2.bat
+++ b/root/programs/VB/z_Common2.bat
@@ -3,13 +3,20 @@
 @rem --------------------------------------------------
 
 @rem --------------------------------------------------
+@rem Set Program Files path
+@rem --------------------------------------------------
+reg Query "HKLM\Hardware\Description\System\CentralProcessor\0" | find /i "x86" > NUL && set PROGRAM_FILES=Program Files || set PROGRAM_FILES=Program Files (x86)
+
+@rem --------------------------------------------------
 @rem Specifying Build tool.
 @rem --------------------------------------------------
-set BUILDFILEPATH="C:\Windows\Microsoft.NET\Framework\v4.0.30319\MSBuild.exe"
+set BUILDFILEPATH="C:\%PROGRAM_FILES%\Microsoft Visual Studio 10.0\Common7\IDE\devenv.com"
 
-set BUILDFILEPATH2.0="C:\Windows\Microsoft.NET\Framework\v2.0.50727\MSBuild.exe"
-set BUILDFILEPATH3.5="C:\Windows\Microsoft.NET\Framework\v3.5\MSBuild.exe"
-set BUILDFILEPATH4.0="C:\Windows\Microsoft.NET\Framework\v4.0.30319\MSBuild.exe"
+set BUILDFILEPATH2.0="C:\%PROGRAM_FILES%\Microsoft Visual Studio 8\Common7\IDE\devenv.com"
+set BUILDFILEPATH3.5="C:\%PROGRAM_FILES%\Microsoft Visual Studio 9.0\Common7\IDE\devenv.com"
+set BUILDFILEPATH4.0="C:\%PROGRAM_FILES%\Microsoft Visual Studio 10.0\Common7\IDE\devenv.com"
+set BUILDFILEPATH4.5="C:\%PROGRAM_FILES%\Microsoft Visual Studio 11.0\Common7\IDE\devenv.com"
+set BUILDFILEPATH4.5.1="C:\%PROGRAM_FILES%\Microsoft Visual Studio 12.0\Common7\IDE\IDE\devenv.com"
 
 @echo --------------------------------------------------
 @echo The choice of build configuration (Debug / Release).
@@ -19,4 +26,4 @@ set BUILD_CONFIG=Debug
 @echo --------------------------------------------------
 @echo Creating a build command.
 @echo --------------------------------------------------
-set COMMANDLINE=/p:Configuration=%BUILD_CONFIG%
+set COMMANDLINE=/build %BUILD_CONFIG%

--- a/root_easysetup/programs/C#/3_Build_PortableClassLibrary.bat
+++ b/root_easysetup/programs/C#/3_Build_PortableClassLibrary.bat
@@ -1,0 +1,26 @@
+setlocal
+
+@rem --------------------------------------------------
+@rem Turn off the echo function.
+@rem --------------------------------------------------
+@echo off
+
+@rem --------------------------------------------------
+@rem Get the path to the executable file.
+@rem --------------------------------------------------
+set CURRENT_DIR=%~dp0
+
+@rem --------------------------------------------------
+@rem Execution of the common processing.
+@rem --------------------------------------------------
+call %CURRENT_DIR%z_Common.bat
+
+rem --------------------------------------------------
+rem Build the batch PortableClassLibrary(PortableClassLibrary)
+rem --------------------------------------------------
+%BUILDFILEPATH% %COMMANDLINE% "Frameworks\PortableClassLibrary\PortableClassLibrary.sln"
+
+pause
+
+rem -------------------------------------------------------
+endlocal

--- a/root_easysetup/programs/C#/z_Common.bat
+++ b/root_easysetup/programs/C#/z_Common.bat
@@ -5,20 +5,19 @@
 @rem --------------------------------------------------
 @rem Specifying Build tool.
 @rem --------------------------------------------------
-set BUILDFILEPATH="C:\Program Files\Microsoft Visual Studio 10.0\Common7\IDE\devenv.com"
+set BUILDFILEPATH="C:\Windows\Microsoft.NET\Framework\v4.0.30319\MSBuild.exe"
 
-set BUILDFILEPATH2.0="C:\Program Files\Microsoft Visual Studio 8\Common7\IDE\devenv.com"
-set BUILDFILEPATH3.5="C:\Program Files\Microsoft Visual Studio 9.0\Common7\IDE\devenv.com"
-set BUILDFILEPATH4.0="C:\Program Files\Microsoft Visual Studio 10.0\Common7\IDE\devenv.com"
-set BUILDFILEPATH4.5="C:\Program Files\Microsoft Visual Studio 11.0\Common7\IDE\devenv.com"
-set BUILDFILEPATH4.5.1="C:\Program Files\Microsoft Visual Studio 12.0\Common7\IDE\IDE\devenv.com"
+set BUILDFILEPATH2.0="C:\Windows\Microsoft.NET\Framework\v2.0.50727\MSBuild.exe"
+set BUILDFILEPATH3.5="C:\Windows\Microsoft.NET\Framework\v3.5\MSBuild.exe"
+set BUILDFILEPATH4.0="C:\Windows\Microsoft.NET\Framework\v4.0.30319\MSBuild.exe"
 
 @echo --------------------------------------------------
 @echo The choice of build configuration (Debug / Release).
 @echo --------------------------------------------------
 set BUILD_CONFIG=Debug
+set VisualStudioVersion=10.0
 
 @echo --------------------------------------------------
 @echo Creating a build command.
 @echo --------------------------------------------------
-set COMMANDLINE=/build %BUILD_CONFIG%
+set COMMANDLINE=/p:Configuration=%BUILD_CONFIG%

--- a/root_easysetup/programs/C#/z_Common2.bat
+++ b/root_easysetup/programs/C#/z_Common2.bat
@@ -3,13 +3,20 @@
 @rem --------------------------------------------------
 
 @rem --------------------------------------------------
+@rem Set Program Files path
+@rem --------------------------------------------------
+reg Query "HKLM\Hardware\Description\System\CentralProcessor\0" | find /i "x86" > NUL && set PROGRAM_FILES=Program Files || set PROGRAM_FILES=Program Files (x86)
+
+@rem --------------------------------------------------
 @rem Specifying Build tool.
 @rem --------------------------------------------------
-set BUILDFILEPATH="C:\Windows\Microsoft.NET\Framework\v4.0.30319\MSBuild.exe"
+set BUILDFILEPATH="C:\%PROGRAM_FILES%\Microsoft Visual Studio 10.0\Common7\IDE\devenv.com"
 
-set BUILDFILEPATH2.0="C:\Windows\Microsoft.NET\Framework\v2.0.50727\MSBuild.exe"
-set BUILDFILEPATH3.5="C:\Windows\Microsoft.NET\Framework\v3.5\MSBuild.exe"
-set BUILDFILEPATH4.0="C:\Windows\Microsoft.NET\Framework\v4.0.30319\MSBuild.exe"
+set BUILDFILEPATH2.0="C:\%PROGRAM_FILES%\Microsoft Visual Studio 8\Common7\IDE\devenv.com"
+set BUILDFILEPATH3.5="C:\%PROGRAM_FILES%\Microsoft Visual Studio 9.0\Common7\IDE\devenv.com"
+set BUILDFILEPATH4.0="C:\%PROGRAM_FILES%\Microsoft Visual Studio 10.0\Common7\IDE\devenv.com"
+set BUILDFILEPATH4.5="C:\%PROGRAM_FILES%\Microsoft Visual Studio 11.0\Common7\IDE\devenv.com"
+set BUILDFILEPATH4.5.1="C:\%PROGRAM_FILES%\Microsoft Visual Studio 12.0\Common7\IDE\IDE\devenv.com"
 
 @echo --------------------------------------------------
 @echo The choice of build configuration (Debug / Release).
@@ -19,4 +26,4 @@ set BUILD_CONFIG=Debug
 @echo --------------------------------------------------
 @echo Creating a build command.
 @echo --------------------------------------------------
-set COMMANDLINE=/p:Configuration=%BUILD_CONFIG%
+set COMMANDLINE=/build %BUILD_CONFIG%

--- a/root_easysetup/programs/VB/z_Common.bat
+++ b/root_easysetup/programs/VB/z_Common.bat
@@ -5,20 +5,19 @@
 @rem --------------------------------------------------
 @rem Specifying Build tool.
 @rem --------------------------------------------------
-set BUILDFILEPATH="C:\Program Files\Microsoft Visual Studio 10.0\Common7\IDE\devenv.com"
+set BUILDFILEPATH="C:\Windows\Microsoft.NET\Framework\v4.0.30319\MSBuild.exe"
 
-set BUILDFILEPATH2.0="C:\Program Files\Microsoft Visual Studio 8\Common7\IDE\devenv.com"
-set BUILDFILEPATH3.5="C:\Program Files\Microsoft Visual Studio 9.0\Common7\IDE\devenv.com"
-set BUILDFILEPATH4.0="C:\Program Files\Microsoft Visual Studio 10.0\Common7\IDE\devenv.com"
-set BUILDFILEPATH4.5="C:\Program Files\Microsoft Visual Studio 11.0\Common7\IDE\devenv.com"
-set BUILDFILEPATH4.5.1="C:\Program Files\Microsoft Visual Studio 12.0\Common7\IDE\IDE\devenv.com"
+set BUILDFILEPATH2.0="C:\Windows\Microsoft.NET\Framework\v2.0.50727\MSBuild.exe"
+set BUILDFILEPATH3.5="C:\Windows\Microsoft.NET\Framework\v3.5\MSBuild.exe"
+set BUILDFILEPATH4.0="C:\Windows\Microsoft.NET\Framework\v4.0.30319\MSBuild.exe"
 
 @echo --------------------------------------------------
 @echo The choice of build configuration (Debug / Release).
 @echo --------------------------------------------------
 set BUILD_CONFIG=Debug
+set VisualStudioVersion=10.0
 
 @echo --------------------------------------------------
 @echo Creating a build command.
 @echo --------------------------------------------------
-set COMMANDLINE=/build %BUILD_CONFIG%
+set COMMANDLINE=/p:Configuration=%BUILD_CONFIG%

--- a/root_easysetup/programs/VB/z_Common2.bat
+++ b/root_easysetup/programs/VB/z_Common2.bat
@@ -3,13 +3,20 @@
 @rem --------------------------------------------------
 
 @rem --------------------------------------------------
+@rem Set Program Files path
+@rem --------------------------------------------------
+reg Query "HKLM\Hardware\Description\System\CentralProcessor\0" | find /i "x86" > NUL && set PROGRAM_FILES=Program Files || set PROGRAM_FILES=Program Files (x86)
+
+@rem --------------------------------------------------
 @rem Specifying Build tool.
 @rem --------------------------------------------------
-set BUILDFILEPATH="C:\Windows\Microsoft.NET\Framework\v4.0.30319\MSBuild.exe"
+set BUILDFILEPATH="C:\%PROGRAM_FILES%\Microsoft Visual Studio 10.0\Common7\IDE\devenv.com"
 
-set BUILDFILEPATH2.0="C:\Windows\Microsoft.NET\Framework\v2.0.50727\MSBuild.exe"
-set BUILDFILEPATH3.5="C:\Windows\Microsoft.NET\Framework\v3.5\MSBuild.exe"
-set BUILDFILEPATH4.0="C:\Windows\Microsoft.NET\Framework\v4.0.30319\MSBuild.exe"
+set BUILDFILEPATH2.0="C:\%PROGRAM_FILES%\Microsoft Visual Studio 8\Common7\IDE\devenv.com"
+set BUILDFILEPATH3.5="C:\%PROGRAM_FILES%\Microsoft Visual Studio 9.0\Common7\IDE\devenv.com"
+set BUILDFILEPATH4.0="C:\%PROGRAM_FILES%\Microsoft Visual Studio 10.0\Common7\IDE\devenv.com"
+set BUILDFILEPATH4.5="C:\%PROGRAM_FILES%\Microsoft Visual Studio 11.0\Common7\IDE\devenv.com"
+set BUILDFILEPATH4.5.1="C:\%PROGRAM_FILES%\Microsoft Visual Studio 12.0\Common7\IDE\IDE\devenv.com"
 
 @echo --------------------------------------------------
 @echo The choice of build configuration (Debug / Release).
@@ -19,4 +26,4 @@ set BUILD_CONFIG=Debug
 @echo --------------------------------------------------
 @echo Creating a build command.
 @echo --------------------------------------------------
-set COMMANDLINE=/p:Configuration=%BUILD_CONFIG%
+set COMMANDLINE=/build %BUILD_CONFIG%


### PR DESCRIPTION
1) Modified the default build tool by replacing the contents of the z_Common.bat and z_Common2.bat
2) To build PortableClassLibrary project, added a new batch file "3_Build_PortableClassLibrary.bat"
3) To resolve the issue of build using MSBuild failed, set the environment variable VisualStudioVersion