### PR TITLE
Merged the issue of IE 11 ignores dialogWidth-Height from C# version

### DIFF
--- a/root/programs/VB/Samples/WebApp_sample/ProjectX_sample/Aspx/Framework/DialogFrame.htm
+++ b/root/programs/VB/Samples/WebApp_sample/ProjectX_sample/Aspx/Framework/DialogFrame.htm
@@ -3,8 +3,6 @@
 <html>
 	<head>
 		<title>ダイアログ画面</title>
-	</head>
-	<frameset cols="100%" style="margin:0px; padding:0px; border-style:none; background-color:#cccccc;">
-        <frame id="frame1" src="./DialogLoader.htm" style="background-color:#cccccc; " />
-    </frameset>
+	</head>	
+	<iframe id="frame1" src="./DialogLoader.htm" frameborder="0" style="overflow:hidden;overflow-x:hidden;overflow-y:hidden;height:100%;width:100%;position:absolute;top:0px;left:0px;right:0px;bottom:0px;"/>
 </html>


### PR DESCRIPTION
@daisukenishino 

IFRAME tag was missing in the VB version.
Please merge it in the nishino branch.