### PR TITLE
Removed the Namespace definitions of Silverlight client the process definition file.

### DIFF
--- a/root/files/resource/Xml/TMInProcessDefinition.xml
+++ b/root/files/resource/Xml/TMInProcessDefinition.xml
@@ -11,9 +11,9 @@
  	<Transmission id="testWebService2" assemblyName="WSServer_sample" className="WSServer_sample.Business.LayerB" />
  	<Transmission id="testWebService3" assemblyName="WSServer_sample" className="WSServer_sample.Business.LayerB" />
 
- 	<Transmission id="muWebService" assemblyName="dummy" className="WSClientSL_sample.Web.Business.LayerB_mu" />
- 	<Transmission id="sbWebService" assemblyName="dummy" className="WSClientSL_sample.Web.Business.LayerB_sb" />
- 	<Transmission id="rtWebService" assemblyName="dummy" className="WSClientSL_sample.Web.Business.LayerB_rt" />
+ 	<Transmission id="muWebService" assemblyName="dummy" className="WinStore_sample.Web.Business.LayerB_mu" />
+ 	<Transmission id="sbWebService" assemblyName="dummy" className="WinStore_sample.Web.Business.LayerB_sb" />
+ 	<Transmission id="rtWebService" assemblyName="dummy" className="WinStore_sample.Web.Business.LayerB_rt" />
 
- 	<Transmission id="Authentication" assemblyName="dummy" className="WSClientSL_sample.Web.Business.Authentication" />
+ 	<Transmission id="Authentication" assemblyName="dummy" className="WinStore_sample.Web.Business.Authentication" />
 </TMD>

--- a/root/programs/C#/Samples/WS_sample/WSClient_sample/WSClientWPF_sample/TMInProcessDefinition.xml
+++ b/root/programs/C#/Samples/WS_sample/WSClient_sample/WSClientWPF_sample/TMInProcessDefinition.xml
@@ -8,9 +8,4 @@
 <TMD>
 	<Transmission id="testInProcess" assemblyName="WSServer_sample" className="WSServer_sample.Business.LayerB" />
  	<Transmission id="testWebService" assemblyName="WSServer_sample" className="WSServer_sample.Business.LayerB" />
-
- 	<Transmission id="muWebService" assemblyName="dummy" className="WSClientSL_sample.Web.Business.LayerB_mu" />
- 	<Transmission id="sbWebService" assemblyName="dummy" className="WSClientSL_sample.Web.Business.LayerB_sb" />
-
- 	<Transmission id="Authentication" assemblyName="dummy" className="WSClientSL_sample.Web.Business.Authentication" />
 </TMD>

--- a/root/programs/C#/Samples/WS_sample/WSClient_sample/WSClientWin2_sample/config/TMInProcessDefinition.xml
+++ b/root/programs/C#/Samples/WS_sample/WSClient_sample/WSClientWin2_sample/config/TMInProcessDefinition.xml
@@ -8,9 +8,4 @@
 <TMD>
 	<Transmission id="testInProcess" assemblyName="WSServer_sample" className="WSServer_sample.Business.LayerB" />
  	<Transmission id="testWebService" assemblyName="WSServer_sample" className="WSServer_sample.Business.LayerB" />
-
- 	<Transmission id="muWebService" assemblyName="dummy" className="WSClientSL_sample.Web.Business.LayerB_mu" />
- 	<Transmission id="sbWebService" assemblyName="dummy" className="WSClientSL_sample.Web.Business.LayerB_sb" />
-
- 	<Transmission id="Authentication" assemblyName="dummy" className="WSClientSL_sample.Web.Business.Authentication" />
 </TMD>

--- a/root/programs/C#/Samples/WS_sample/WSClient_sample/WSClientWin_sample/TMInProcessDefinition.xml
+++ b/root/programs/C#/Samples/WS_sample/WSClient_sample/WSClientWin_sample/TMInProcessDefinition.xml
@@ -8,9 +8,4 @@
 <TMD>
 	<Transmission id="testInProcess" assemblyName="WSServer_sample" className="WSServer_sample.Business.LayerB" />
  	<Transmission id="testWebService" assemblyName="WSServer_sample" className="WSServer_sample.Business.LayerB" />
-
- 	<Transmission id="muWebService" assemblyName="dummy" className="WSClientSL_sample.Web.Business.LayerB_mu" />
- 	<Transmission id="sbWebService" assemblyName="dummy" className="WSClientSL_sample.Web.Business.LayerB_sb" />
-
- 	<Transmission id="Authentication" assemblyName="dummy" className="WSClientSL_sample.Web.Business.Authentication" />
 </TMD>

--- a/root/programs/VB/Samples/WS_sample/WSClient_sample/WSClientWPF_sample/TMInProcessDefinition.xml
+++ b/root/programs/VB/Samples/WS_sample/WSClient_sample/WSClientWPF_sample/TMInProcessDefinition.xml
@@ -8,9 +8,4 @@
 <TMD>
 	<Transmission id="testInProcess" assemblyName="WSServer_sample" className="WSServer_sample.Business.LayerB" />
  	<Transmission id="testWebService" assemblyName="WSServer_sample" className="WSServer_sample.Business.LayerB" />
-
- 	<Transmission id="muWebService" assemblyName="dummy" className="WSClientSL_sample.Web.Business.LayerB_mu" />
- 	<Transmission id="sbWebService" assemblyName="dummy" className="WSClientSL_sample.Web.Business.LayerB_sb" />
-
- 	<Transmission id="Authentication" assemblyName="dummy" className="WSClientSL_sample.Web.Business.Authentication" />
 </TMD>

--- a/root/programs/VB/Samples/WS_sample/WSClient_sample/WSClientWin2_sample/config/TMInProcessDefinition.xml
+++ b/root/programs/VB/Samples/WS_sample/WSClient_sample/WSClientWin2_sample/config/TMInProcessDefinition.xml
@@ -8,9 +8,4 @@
 <TMD>
 	<Transmission id="testInProcess" assemblyName="WSServer_sample" className="WSServer_sample.Business.LayerB" />
  	<Transmission id="testWebService" assemblyName="WSServer_sample" className="WSServer_sample.Business.LayerB" />
-
- 	<Transmission id="muWebService" assemblyName="dummy" className="WSClientSL_sample.Web.Business.LayerB_mu" />
- 	<Transmission id="sbWebService" assemblyName="dummy" className="WSClientSL_sample.Web.Business.LayerB_sb" />
-
- 	<Transmission id="Authentication" assemblyName="dummy" className="WSClientSL_sample.Web.Business.Authentication" />
 </TMD>

--- a/root/programs/VB/Samples/WS_sample/WSClient_sample/WSClientWin_sample/TMInProcessDefinition.xml
+++ b/root/programs/VB/Samples/WS_sample/WSClient_sample/WSClientWin_sample/TMInProcessDefinition.xml
@@ -8,9 +8,4 @@
 <TMD>
 	<Transmission id="testInProcess" assemblyName="WSServer_sample" className="WSServer_sample.Business.LayerB" />
  	<Transmission id="testWebService" assemblyName="WSServer_sample" className="WSServer_sample.Business.LayerB" />
-
- 	<Transmission id="muWebService" assemblyName="dummy" className="WSClientSL_sample.Web.Business.LayerB_mu" />
- 	<Transmission id="sbWebService" assemblyName="dummy" className="WSClientSL_sample.Web.Business.LayerB_sb" />
-
- 	<Transmission id="Authentication" assemblyName="dummy" className="WSClientSL_sample.Web.Business.Authentication" />
 </TMD>


### PR DESCRIPTION
The following codes are modified, due to deprecation of Silverlight support.

- In [/files/resource/Xml/TMInProcessDefinition.xml](https://github.com/OpenTouryoProject/OpenTouryo/blob/develop/root/files/resource/Xml/TMInProcessDefinition.xml) file, renamed the Namespace of silverlight client from WSClientSL_sample to WinStore_sample.

- In other files, removed the Namespace definitions of Silverlight client.