### PR TITLE
Increased the width of control because control name was not completely displaying on the UI

### DIFF
--- a/root/programs/C#/Frameworks/Tools/DaoGen_Tool/Form2.ja-JP.resx
+++ b/root/programs/C#/Frameworks/Tools/DaoGen_Tool/Form2.ja-JP.resx
@@ -295,6 +295,9 @@
   <data name="cbxTableMaintenance.Location" type="System.Drawing.Point, System.Drawing">
     <value>5, 42</value>
   </data>
+  <data name="cbxTableMaintenance.Size" type="System.Drawing.Size, System.Drawing">
+    <value>220, 17</value>
+  </data>
   <data name="groupBox3.Size" type="System.Drawing.Size, System.Drawing">
     <value>525, 76</value>
   </data>


### PR DESCRIPTION
@daisukenishino 

As discussed [here](https://github.com/SymphonyTeleca/OpenTouryo/pull/109#issuecomment-199681961),
We have resized the control to display complete name.